### PR TITLE
feat: importar hospedes via planilha

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -18,3 +18,26 @@ CREATE TABLE IF NOT EXISTS sessions (
   revoked_at TIMESTAMP,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Tabela para armazenar hóspedes importados de planilhas
+CREATE TABLE IF NOT EXISTS hospedes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  codigo TEXT,
+  apto TEXT,
+  nome_completo TEXT,
+  endereco TEXT,
+  estado TEXT,
+  email TEXT,
+  profissao TEXT,
+  cidade TEXT,
+  identidade TEXT,
+  cpf TEXT,
+  telefone TEXT,
+  pais TEXT,
+  cep TEXT,
+  data_nascimento TEXT,
+  sexo TEXT,
+  entrada TEXT,
+  saida TEXT,
+  status TEXT
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,9 @@
     "dotenv": "^16.3.1",
     "helmet": "^7.1.0",
     "express-rate-limit": "^7.1.5",
-    "swagger-ui-express": "^4.6.3"
+    "swagger-ui-express": "^4.6.3",
+    "multer": "^1.4.5-lts.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const multer = require('multer');
+const XLSX = require('xlsx');
+const fs = require('fs');
+const path = require('path');
+const { getDatabase } = require('../config/database');
+
+const upload = multer({ dest: path.join(__dirname, '../uploads') });
+const router = express.Router();
+
+// Importar planilha de hóspedes
+router.post('/import', upload.single('file'), async (req, res, next) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'Arquivo não enviado' });
+    }
+    const filePath = req.file.path;
+    const workbook = XLSX.readFile(filePath);
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+
+    const db = getDatabase();
+    const inserts = [];
+    for (let i = 1; i < rows.length; i++) {
+      const r = rows[i];
+      if (!r || r.length === 0 || r.every(cell => cell === '')) continue;
+      const [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida] = r;
+      inserts.push(db.query(
+        `INSERT INTO hospedes (codigo, apto, nome_completo, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, data_nascimento, sexo, entrada, saida, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 'importado']
+      ));
+    }
+    await Promise.all(inserts);
+    fs.unlinkSync(filePath);
+    res.json({ message: 'Importação concluída', inserted: inserts.length });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Listar hóspedes
+router.get('/', async (req, res, next) => {
+  try {
+    const db = getDatabase();
+    const result = await db.query('SELECT * FROM hospedes');
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ const { ApiError, errorHandler } = require('./middleware/errorHandler');
 
 // Importar rotas
 const authRoutes = require('./routes/auth');
+const hospedeRoutes = require('./routes/hospedes');
 
 // Importar configuração do banco de dados
 const { initDatabase } = require('./config/database');
@@ -83,6 +84,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 // Rotas de autenticação (aplicar rate limiting específico)
 app.use('/auth/login', loginLimiter);
 app.use('/auth', authRoutes);
+app.use('/hospedes', hospedeRoutes);
 
 // Rota para servir arquivos estáticos (se necessário)
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,8 @@ import { Routes } from '@angular/router';
 export const routes: Routes = [
   { path: 'login', loadComponent: () => import('./components/login/login').then(m => m.LoginComponent) },
   { path: 'reset-password', loadComponent: () => import('./components/reset-password/reset-password').then(m => m.ResetPasswordComponent) },
+  { path: 'hospedes/import', loadComponent: () => import('./components/hospedes-import/hospedes-import').then(m => m.HospedesImportComponent) },
+  { path: 'hospedes', loadComponent: () => import('./components/hospedes-list/hospedes-list').then(m => m.HospedesListComponent) },
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: '**', redirectTo: 'login' }
 ];

--- a/frontend/src/app/components/hospedes-import/hospedes-import.html
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.html
@@ -1,0 +1,4 @@
+<h2>Importar Hóspedes</h2>
+<input type="file" (change)="onFile($event)" />
+<button (click)="upload()" [disabled]="!file">Importar</button>
+<a routerLink="/hospedes">Voltar</a>

--- a/frontend/src/app/components/hospedes-import/hospedes-import.scss
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  padding: 1rem;
+}

--- a/frontend/src/app/components/hospedes-import/hospedes-import.ts
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { HospedesService } from '../../services/hospedes.service';
+
+@Component({
+  selector: 'app-hospedes-import',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './hospedes-import.html',
+  styleUrls: ['./hospedes-import.scss']
+})
+export class HospedesImportComponent {
+  file?: File;
+
+  constructor(private service: HospedesService, private router: Router) {}
+
+  onFile(event: Event) {
+    const target = event.target as HTMLInputElement;
+    if (target.files && target.files.length) {
+      this.file = target.files[0];
+    }
+  }
+
+  upload() {
+    if (!this.file) return;
+    this.service.import(this.file).subscribe(() => {
+      this.router.navigate(['/hospedes']);
+    });
+  }
+}

--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -1,0 +1,48 @@
+<h2>Hóspedes</h2>
+<a routerLink="/hospedes/import">Importar planilha</a>
+<table>
+  <thead>
+    <tr>
+      <th>Código</th>
+      <th>Apto</th>
+      <th>Nome Completo</th>
+      <th>Endereço</th>
+      <th>Estado</th>
+      <th>E-mail</th>
+      <th>Profissão</th>
+      <th>Cidade</th>
+      <th>Identidade</th>
+      <th>CPF</th>
+      <th>Telefone</th>
+      <th>País</th>
+      <th>Cep</th>
+      <th>Data Nascimento</th>
+      <th>Sexo</th>
+      <th>Entrada</th>
+      <th>Saída</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let h of hospedes">
+      <td>{{h.codigo}}</td>
+      <td>{{h.apto}}</td>
+      <td>{{h.nome_completo}}</td>
+      <td>{{h.endereco}}</td>
+      <td>{{h.estado}}</td>
+      <td>{{h.email}}</td>
+      <td>{{h.profissao}}</td>
+      <td>{{h.cidade}}</td>
+      <td>{{h.identidade}}</td>
+      <td>{{h.cpf}}</td>
+      <td>{{h.telefone}}</td>
+      <td>{{h.pais}}</td>
+      <td>{{h.cep}}</td>
+      <td>{{h.data_nascimento}}</td>
+      <td>{{h.sexo}}</td>
+      <td>{{h.entrada}}</td>
+      <td>{{h.saida}}</td>
+      <td>{{h.status}}</td>
+    </tr>
+  </tbody>
+</table>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.scss
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.scss
@@ -1,0 +1,19 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.25rem;
+  font-size: 0.75rem;
+}
+
+th {
+  background: #f0f0f0;
+}

--- a/frontend/src/app/components/hospedes-list/hospedes-list.ts
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { HospedesService } from '../../services/hospedes.service';
+
+@Component({
+  selector: 'app-hospedes-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './hospedes-list.html',
+  styleUrls: ['./hospedes-list.scss']
+})
+export class HospedesListComponent implements OnInit {
+  hospedes: any[] = [];
+
+  constructor(private service: HospedesService) {}
+
+  ngOnInit(): void {
+    this.service.list().subscribe(data => this.hospedes = data);
+  }
+}

--- a/frontend/src/app/services/hospedes.service.ts
+++ b/frontend/src/app/services/hospedes.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class HospedesService {
+  private baseUrl = '/hospedes';
+
+  constructor(private http: HttpClient) {}
+
+  import(file: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post(`${this.baseUrl}/import`, formData);
+  }
+
+  list(): Observable<any[]> {
+    return this.http.get<any[]>(this.baseUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add `hospedes` table with status column
- support spreadsheet import and listing endpoints
- create Angular screens to upload and view imported guests

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run build --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68b85bf129e0832e9af5c26de874c2e9