### PR TITLE
feat(frontend): redirect to home after login

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,10 +1,12 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './guards/auth-guard';
 
 export const routes: Routes = [
   { path: 'login', loadComponent: () => import('./components/login/login').then(m => m.LoginComponent) },
+  { path: 'home', loadComponent: () => import('./components/home/home').then(m => m.HomeComponent), canActivate: [authGuard] },
   { path: 'reset-password', loadComponent: () => import('./components/reset-password/reset-password').then(m => m.ResetPasswordComponent) },
-  { path: 'hospedes/import', loadComponent: () => import('./components/hospedes-import/hospedes-import').then(m => m.HospedesImportComponent) },
-  { path: 'hospedes', loadComponent: () => import('./components/hospedes-list/hospedes-list').then(m => m.HospedesListComponent) },
-  { path: '', redirectTo: 'login', pathMatch: 'full' },
-  { path: '**', redirectTo: 'login' }
+  { path: 'hospedes/import', loadComponent: () => import('./components/hospedes-import/hospedes-import').then(m => m.HospedesImportComponent), canActivate: [authGuard] },
+  { path: 'hospedes', loadComponent: () => import('./components/hospedes-list/hospedes-list').then(m => m.HospedesListComponent), canActivate: [authGuard] },
+  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  { path: '**', redirectTo: 'home' }
 ];

--- a/frontend/src/app/components/login/login.ts
+++ b/frontend/src/app/components/login/login.ts
@@ -44,7 +44,8 @@ export class LoginComponent implements OnInit {
   };
 
   isLoading = false;
-  returnUrl = '/';
+  // URL padrão para a página inicial após o login
+  returnUrl = '/home';
 
   constructor(
     private authService: AuthService,
@@ -54,8 +55,8 @@ export class LoginComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    // Obter URL de retorno dos query params
-    this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/';
+    // Obter URL de retorno dos query params ou usar página inicial padrão
+    this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/home';
 
     // Se já estiver autenticado, redirecionar
     if (this.authService.isAuthenticated()) {


### PR DESCRIPTION
## Summary
- redirect authenticated users to the new `home` route
- protect application routes with auth guard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b87eac658c832eb2c20c1de346a344