### PR TITLE
feat: wrap main routes with master layout

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,10 +3,23 @@ import { authGuard } from './guards/auth-guard';
 
 export const routes: Routes = [
   { path: 'login', loadComponent: () => import('./components/login/login').then(m => m.LoginComponent) },
-  { path: 'home', loadComponent: () => import('./components/home/home').then(m => m.HomeComponent), canActivate: [authGuard] },
   { path: 'reset-password', loadComponent: () => import('./components/reset-password/reset-password').then(m => m.ResetPasswordComponent) },
-  { path: 'hospedes/import', loadComponent: () => import('./components/hospedes-import/hospedes-import').then(m => m.HospedesImportComponent), canActivate: [authGuard] },
-  { path: 'hospedes', loadComponent: () => import('./components/hospedes-list/hospedes-list').then(m => m.HospedesListComponent), canActivate: [authGuard] },
-  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  {
+    path: '',
+    canActivate: [authGuard],
+    loadComponent: () => import('./components/layout/component/master-layout').then(m => m.MasterLayoutComponent),
+    children: [
+      { path: 'home', loadComponent: () => import('./components/home/home').then(m => m.HomeComponent) },
+      {
+        path: 'hospedes/import',
+        loadComponent: () => import('./components/hospedes-import/hospedes-import').then(m => m.HospedesImportComponent)
+      },
+      {
+        path: 'hospedes',
+        loadComponent: () => import('./components/hospedes-list/hospedes-list').then(m => m.HospedesListComponent)
+      },
+      { path: '', redirectTo: 'home', pathMatch: 'full' }
+    ]
+  },
   { path: '**', redirectTo: 'home' }
 ];


### PR DESCRIPTION
## Summary
- route authenticated pages through master layout component for consistent base layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8833825ac832e8b86ed5c3ebdd954