### PR TITLE
style: apply PrimeNG layout for guest list and import

### DIFF
--- a/frontend/src/app/components/hospedes-import/hospedes-import.html
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.html
@@ -1,4 +1,4 @@
 <h2>Importar Hóspedes</h2>
-<input type="file" (change)="onFile($event)" />
-<button (click)="upload()" [disabled]="!file">Importar</button>
-<a routerLink="/hospedes">Voltar</a>
+<p-fileUpload mode="basic" chooseLabel="Selecionar arquivo" (onSelect)="onFile($event)" (clear)="file=undefined"></p-fileUpload>
+<p-button label="Importar" (onClick)="upload()" [disabled]="!file"></p-button>
+<p-button label="Voltar" [routerLink]="['/hospedes']" styleClass="p-button-secondary"></p-button>

--- a/frontend/src/app/components/hospedes-import/hospedes-import.scss
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.scss
@@ -2,3 +2,8 @@
   display: block;
   padding: 1rem;
 }
+
+::ng-deep .p-button {
+  margin-right: 0.5rem;
+  margin-top: 1rem;
+}

--- a/frontend/src/app/components/hospedes-import/hospedes-import.ts
+++ b/frontend/src/app/components/hospedes-import/hospedes-import.ts
@@ -2,11 +2,13 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { HospedesService } from '../../services/hospedes.service';
+import { FileUploadModule, FileSelectEvent } from 'primeng/fileupload';
+import { ButtonModule } from 'primeng/button';
 
 @Component({
   selector: 'app-hospedes-import',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FileUploadModule, ButtonModule],
   templateUrl: './hospedes-import.html',
   styleUrls: ['./hospedes-import.scss']
 })
@@ -15,10 +17,9 @@ export class HospedesImportComponent {
 
   constructor(private service: HospedesService, private router: Router) {}
 
-  onFile(event: Event) {
-    const target = event.target as HTMLInputElement;
-    if (target.files && target.files.length) {
-      this.file = target.files[0];
+  onFile(event: FileSelectEvent) {
+    if (event.files && event.files.length) {
+      this.file = event.files[0];
     }
   }
 

--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -1,7 +1,7 @@
 <h2>Hóspedes</h2>
-<a routerLink="/hospedes/import">Importar planilha</a>
-<table>
-  <thead>
+<p-button label="Importar planilha" [routerLink]="['/hospedes/import']"></p-button>
+<p-table [value]="hospedes" responsiveLayout="scroll">
+  <ng-template pTemplate="header">
     <tr>
       <th>Código</th>
       <th>Apto</th>
@@ -22,27 +22,27 @@
       <th>Saída</th>
       <th>Status</th>
     </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let h of hospedes">
-      <td>{{h.codigo}}</td>
-      <td>{{h.apto}}</td>
-      <td>{{h.nome_completo}}</td>
-      <td>{{h.endereco}}</td>
-      <td>{{h.estado}}</td>
-      <td>{{h.email}}</td>
-      <td>{{h.profissao}}</td>
-      <td>{{h.cidade}}</td>
-      <td>{{h.identidade}}</td>
-      <td>{{h.cpf}}</td>
-      <td>{{h.telefone}}</td>
-      <td>{{h.pais}}</td>
-      <td>{{h.cep}}</td>
-      <td>{{h.data_nascimento}}</td>
-      <td>{{h.sexo}}</td>
-      <td>{{h.entrada}}</td>
-      <td>{{h.saida}}</td>
-      <td>{{h.status}}</td>
+  </ng-template>
+  <ng-template pTemplate="body" let-h>
+    <tr>
+      <td>{{ h.codigo }}</td>
+      <td>{{ h.apto }}</td>
+      <td>{{ h.nome_completo }}</td>
+      <td>{{ h.endereco }}</td>
+      <td>{{ h.estado }}</td>
+      <td>{{ h.email }}</td>
+      <td>{{ h.profissao }}</td>
+      <td>{{ h.cidade }}</td>
+      <td>{{ h.identidade }}</td>
+      <td>{{ h.cpf }}</td>
+      <td>{{ h.telefone }}</td>
+      <td>{{ h.pais }}</td>
+      <td>{{ h.cep }}</td>
+      <td>{{ h.data_nascimento }}</td>
+      <td>{{ h.sexo }}</td>
+      <td>{{ h.entrada }}</td>
+      <td>{{ h.saida }}</td>
+      <td>{{ h.status }}</td>
     </tr>
-  </tbody>
-</table>
+  </ng-template>
+</p-table>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.scss
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.scss
@@ -3,17 +3,6 @@
   padding: 1rem;
 }
 
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th, td {
-  border: 1px solid #ccc;
-  padding: 0.25rem;
-  font-size: 0.75rem;
-}
-
-th {
-  background: #f0f0f0;
+::ng-deep .p-button {
+  margin-bottom: 1rem;
 }

--- a/frontend/src/app/components/hospedes-list/hospedes-list.ts
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.ts
@@ -1,12 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { TableModule } from 'primeng/table';
+import { ButtonModule } from 'primeng/button';
 import { HospedesService } from '../../services/hospedes.service';
 
 @Component({
   selector: 'app-hospedes-list',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, TableModule, ButtonModule],
   templateUrl: './hospedes-list.html',
   styleUrls: ['./hospedes-list.scss']
 })


### PR DESCRIPTION
## Summary
- refactor guest list to use PrimeNG table and button components
- restyle guest import with PrimeNG file upload and navigation buttons
- remove custom table styling and add spacing for PrimeNG controls

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8873cce18832e9f9405f193c85fc2