### PR TITLE
Default imported guests status to not linked

### DIFF
--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -28,7 +28,7 @@ router.post('/import', upload.single('file'), async (req, res, next) => {
       inserts.push(db.query(
         `INSERT INTO hospedes (codigo, apto, nome_completo, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, data_nascimento, sexo, entrada, saida, status)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 'importado']
+        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 1]
       ));
     }
     await Promise.all(inserts);

--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -20,7 +20,6 @@
       <th>Sexo</th>
       <th>Entrada</th>
       <th>Saída</th>
-      <th>Status</th>
     </tr>
   </ng-template>
   <ng-template pTemplate="body" let-h>
@@ -42,7 +41,6 @@
       <td>{{ h.sexo }}</td>
       <td>{{ h.entrada }}</td>
       <td>{{ h.saida }}</td>
-      <td>{{ h.status }}</td>
     </tr>
   </ng-template>
 </p-table>


### PR DESCRIPTION
## Summary
- Set default status to 1 for guests imported via spreadsheet
- Remove status column from guests list to hide it from the UI

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` (backend) *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8888ff090832ebf1495b74a83f647