### PR TITLE
fix: use backend URL for hospedes service

### DIFF
--- a/frontend/src/app/services/hospedes.service.ts
+++ b/frontend/src/app/services/hospedes.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class HospedesService {
-  private baseUrl = '/hospedes';
+  private baseUrl = `${environment.apiUrl}/hospedes`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- ensure HospedesService uses environment API URL to call backend

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b88ddd77fc832eb27ceac561acc409