### PR TITLE
Handle missing guest deletion

### DIFF
--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -54,7 +54,10 @@ router.get('/', async (req, res, next) => {
 router.delete('/:id', async (req, res, next) => {
   try {
     const db = getDatabase();
-    await db.query('DELETE FROM hospedes WHERE id = ?', [req.params.id]);
+    const result = await db.query('DELETE FROM hospedes WHERE id = ?', [req.params.id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Hóspede não encontrado' });
+    }
     res.status(204).send();
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- return a not found error when trying to delete a non-existent guest

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test` in backend *(fails: Missing script "test")*
- `npm test` in frontend *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b88feadeb4832ebe46d48b5dfe5e18