### PR TITLE
Handle missing guest deletion

### DIFF
--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -8,7 +8,12 @@ class ApiError extends Error {
 }
 
 function errorHandler(err, req, res, next) {
-  console.error('❌', err.message, err.details || err.stack);
+  const status = err.statusCode || 500;
+  if (status >= 500) {
+    console.error('❌', err.message, err.details || err.stack);
+  } else {
+    console.warn('⚠️', err.message);
+  }
 
   if (err.name === 'JsonWebTokenError') {
     return res.status(401).json({ error: 'Token inválido', code: 'TOKEN_INVALID' });
@@ -16,8 +21,6 @@ function errorHandler(err, req, res, next) {
   if (err.name === 'TokenExpiredError') {
     return res.status(401).json({ error: 'Token expirado', code: 'TOKEN_EXPIRED' });
   }
-
-  const status = err.statusCode || 500;
 
   if (status === 400) {
     const response = { success: false, errors: [err.message] };

--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -54,7 +54,10 @@ router.get('/', async (req, res, next) => {
 router.delete('/:id', async (req, res, next) => {
   try {
     const db = getDatabase();
-    await db.query('DELETE FROM hospedes WHERE id = ?', [req.params.id]);
+    const result = await db.query('DELETE FROM hospedes WHERE id = ?', [req.params.id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Hóspede não encontrado' });
+    }
     res.status(204).send();
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- return a not found error when trying to delete a non-existent guest
- log unknown routes without noisy stack traces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test` in backend *(fails: Missing script "test")*
- `npm test` in frontend *(fails: Missing script "test")*
- `curl -I http://localhost:3000/unknown`


------
https://chatgpt.com/codex/tasks/task_e_68b88feadeb4832ebe46d48b5dfe5e18