### PR TITLE
Add reservation compatibility lookup from listing screen

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -39,5 +39,7 @@ CREATE TABLE IF NOT EXISTS hospedes (
   sexo TEXT,
   entrada TEXT,
   saida TEXT,
-  status TEXT
+  status TEXT,
+  idhospede TEXT,
+  idreservasfront TEXT
 );

--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -4,9 +4,81 @@ const XLSX = require('xlsx');
 const fs = require('fs');
 const path = require('path');
 const { getSqliteDb } = require('../config/database');
+const { buscarReservaOracle } = require('../config/oracleDatabase');
 
 const upload = multer({ dest: path.join(__dirname, '../uploads') });
 const router = express.Router();
+
+let colunasExtrasVerificadas = false;
+
+function normalizarDataOracle(valor) {
+  if (!valor && valor !== 0) {
+    return null;
+  }
+
+  const texto = String(valor).trim();
+  if (!texto) {
+    return null;
+  }
+
+  const isoMatch = texto.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+  }
+
+  const brMatch = texto.match(/^(\d{2})\/(\d{2})\/(\d{4})/);
+  if (brMatch) {
+    return `${brMatch[3]}-${brMatch[2]}-${brMatch[1]}`;
+  }
+
+  const parsed = new Date(texto);
+  if (!Number.isNaN(parsed.getTime())) {
+    const year = parsed.getFullYear();
+    const month = String(parsed.getMonth() + 1).padStart(2, '0');
+    const day = String(parsed.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  return null;
+}
+
+function separarNomeSobrenome(nomeCompleto) {
+  if (!nomeCompleto) {
+    return { nome: null, sobrenome: null };
+  }
+
+  const partes = String(nomeCompleto)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (partes.length === 0) {
+    return { nome: null, sobrenome: null };
+  }
+
+  const nome = partes.shift();
+  const sobrenome = partes.length > 0 ? partes.join(' ') : nome;
+  return { nome, sobrenome };
+}
+
+async function garantirColunasExtras(db) {
+  if (colunasExtrasVerificadas) {
+    return;
+  }
+
+  const info = await db.query('PRAGMA table_info(hospedes)');
+  const nomesColunas = info.rows.map(coluna => coluna.name || coluna.NAME);
+
+  if (!nomesColunas.includes('idhospede')) {
+    await db.query('ALTER TABLE hospedes ADD COLUMN idhospede TEXT');
+  }
+
+  if (!nomesColunas.includes('idreservasfront')) {
+    await db.query('ALTER TABLE hospedes ADD COLUMN idreservasfront TEXT');
+  }
+
+  colunasExtrasVerificadas = true;
+}
 
 // Importar planilha de hóspedes
 router.post('/import', upload.single('file'), async (req, res, next) => {
@@ -20,15 +92,17 @@ router.post('/import', upload.single('file'), async (req, res, next) => {
     const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
 
     const db = getSqliteDb();
+    await garantirColunasExtras(db);
+
     const inserts = [];
     for (let i = 1; i < rows.length; i++) {
       const r = rows[i];
       if (!r || r.length === 0 || r.every(cell => cell === '')) continue;
       const [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida] = r;
       inserts.push(db.query(
-        `INSERT INTO hospedes (codigo, apto, nome_completo, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, data_nascimento, sexo, entrada, saida, status)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 1]
+        `INSERT INTO hospedes (codigo, apto, nome_completo, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, data_nascimento, sexo, entrada, saida, status, idhospede, idreservasfront)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 1, null, null]
       ));
     }
     await Promise.all(inserts);
@@ -43,9 +117,75 @@ router.post('/import', upload.single('file'), async (req, res, next) => {
 router.get('/', async (req, res, next) => {
   try {
     const db = getSqliteDb();
+    await garantirColunasExtras(db);
+
     const result = await db.query('SELECT * FROM hospedes');
     res.json(result.rows);
   } catch (err) {
+    next(err);
+  }
+});
+
+// Buscar compatibilidade de reserva no Oracle e atualizar ficha
+router.post('/:id/compatibilidade', async (req, res, next) => {
+  try {
+    const db = getSqliteDb();
+    await garantirColunasExtras(db);
+
+    const hospedeResult = await db.query('SELECT * FROM hospedes WHERE id = ?', [req.params.id]);
+
+    if (hospedeResult.rowCount === 0) {
+      return res.status(404).json({ error: 'Hóspede não encontrado' });
+    }
+
+    const hospede = hospedeResult.rows[0];
+    const { nome, sobrenome } = separarNomeSobrenome(hospede.nome_completo);
+
+    if (!nome || !sobrenome) {
+      return res.status(400).json({ error: 'Nome do hóspede inválido para buscar no Oracle' });
+    }
+
+    const dataChegadaPrevista = normalizarDataOracle(hospede.entrada);
+    const dataPartidaPrevista = normalizarDataOracle(hospede.saida);
+
+    if (!dataChegadaPrevista || !dataPartidaPrevista) {
+      return res.status(400).json({ error: 'Datas de entrada/saída inválidas para buscar no Oracle' });
+    }
+
+    const reservas = await buscarReservaOracle({
+      dataChegadaPrevista,
+      dataPartidaPrevista,
+      nomeHospede: nome,
+      sobrenomeHospede: sobrenome
+    });
+
+    if (!reservas || reservas.length === 0) {
+      return res.status(404).json({ error: 'Nenhuma reserva compatível encontrada no Oracle' });
+    }
+
+    const reserva = reservas[0];
+    const idHospedeOracle =
+      reserva.IDHOSPEDE ?? reserva.idhospede ?? reserva.IdHospede ?? reserva.idHospede ?? null;
+    const idReservasFrontOracle =
+      reserva.IDRESERVASFRONT ?? reserva.idreservasfront ?? reserva.IdReservasFront ?? reserva.idReservasFront ?? null;
+
+    await db.query('UPDATE hospedes SET idhospede = ?, idreservasfront = ? WHERE id = ?', [
+      idHospedeOracle,
+      idReservasFrontOracle,
+      req.params.id
+    ]);
+
+    const atualizado = await db.query('SELECT * FROM hospedes WHERE id = ?', [req.params.id]);
+
+    res.json({
+      message: 'Reserva compatível encontrada e ficha atualizada',
+      hospede: atualizado.rows[0],
+      reserva
+    });
+  } catch (err) {
+    if (err && err.message && err.message.includes('Oracle Database indisponível')) {
+      return res.status(503).json({ error: err.message });
+    }
     next(err);
   }
 });

--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -22,6 +22,8 @@
       <th>Sexo</th>
       <th>Entrada</th>
       <th>Saída</th>
+      <th>ID Hóspede Oracle</th>
+      <th>ID Reserva Oracle</th>
       <th>Ações</th>
     </tr>
   </ng-template>
@@ -44,7 +46,16 @@
       <td>{{ h.sexo }}</td>
       <td>{{ h.entrada }}</td>
       <td>{{ h.saida }}</td>
+      <td>{{ h.idhospede || '-' }}</td>
+      <td>{{ h.idreservasfront || '-' }}</td>
       <td>
+        <p-button
+          icon="pi pi-search"
+          label="Compatibilidade"
+          (click)="buscarCompatibilidade(h)"
+          [loading]="buscandoCompatibilidade[h.id]"
+          styleClass="compatibilidade-button"
+        ></p-button>
         <p-button icon="pi pi-trash" severity="danger" (click)="remove(h.id)" rounded outlined></p-button>
       </td>
     </tr>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.scss
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.scss
@@ -9,3 +9,7 @@
   align-items: center;
   margin-bottom: 1rem;
 }
+
+.compatibilidade-button {
+  margin-right: 0.5rem;
+}

--- a/frontend/src/app/components/hospedes-list/hospedes-list.ts
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.ts
@@ -14,11 +14,41 @@ import { HospedesService } from '../../services/hospedes.service';
 })
 export class HospedesListComponent implements OnInit {
   hospedes: any[] = [];
+  buscandoCompatibilidade: Record<number, boolean> = {};
 
   constructor(private service: HospedesService) {}
 
   ngOnInit(): void {
     this.service.list().subscribe(data => this.hospedes = data);
+  }
+
+  buscarCompatibilidade(hospede: any): void {
+    if (!hospede || !hospede.id) {
+      return;
+    }
+
+    const id = hospede.id;
+    this.buscandoCompatibilidade[id] = true;
+
+    this.service.buscarCompatibilidade(id).subscribe({
+      next: response => {
+        this.buscandoCompatibilidade[id] = false;
+
+        const dadosAtualizados = response?.hospede;
+        if (dadosAtualizados) {
+          Object.assign(hospede, dadosAtualizados);
+        }
+
+        if (response?.message) {
+          window.alert(response.message);
+        }
+      },
+      error: err => {
+        this.buscandoCompatibilidade[id] = false;
+        const mensagem = err?.error?.error || 'Erro ao buscar compatibilidade da reserva';
+        window.alert(mensagem);
+      }
+    });
   }
 
   remove(id: number): void {

--- a/frontend/src/app/services/hospedes.service.ts
+++ b/frontend/src/app/services/hospedes.service.ts
@@ -19,6 +19,10 @@ export class HospedesService {
     return this.http.get<any[]>(this.baseUrl);
   }
 
+  buscarCompatibilidade(id: number): Observable<any> {
+    return this.http.post<any>(`${this.baseUrl}/${id}/compatibilidade`, {});
+  }
+
   delete(id: number): Observable<void> {
     return this.http.delete<void>(`${this.baseUrl}/${id}`);
   }


### PR DESCRIPTION
## Summary
- add an API endpoint that checks Oracle for matching reservations and stores the guest/reservation identifiers
- ensure the SQLite schema (and legacy databases) include the Oracle identifier columns during imports and listings
- expose the compatibility action in the guest list with UI feedback and an updated service method

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0d5a6644832e971204e94936067f