### PR TITLE
feat: modernize hospedes list layout

### DIFF
--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -1,63 +1,121 @@
-<div class="header">
-  <h2>Hóspedes</h2>
-  <p-button label="Importar planilha" [routerLink]="['/hospedes/import']"></p-button>
-</div>
-<p-table [value]="hospedes" responsiveLayout="scroll">
+<p-panel styleClass="hospedes-panel">
   <ng-template pTemplate="header">
-    <tr>
-      <th>Código</th>
-      <th>Apto</th>
-      <th>Nome Completo</th>
-      <th>Endereço</th>
-      <th>Estado</th>
-      <th>E-mail</th>
-      <th>Profissão</th>
-      <th>Cidade</th>
-      <th>Identidade</th>
-      <th>CPF</th>
-      <th>Telefone</th>
-      <th>País</th>
-      <th>Cep</th>
-      <th>Data Nascimento</th>
-      <th>Sexo</th>
-      <th>Entrada</th>
-      <th>Saída</th>
-      <th>ID Hóspede Oracle</th>
-      <th>ID Reserva Oracle</th>
-      <th>Ações</th>
-    </tr>
+    <div class="panel-header">
+      <div class="panel-header__titles">
+        <h2>Hóspedes</h2>
+        <p class="subtitle">Visualize e gerencie os cadastros importados do hotel.</p>
+      </div>
+      <p-button label="Importar planilha" icon="pi pi-upload" [routerLink]="['/hospedes/import']"></p-button>
+    </div>
   </ng-template>
-  <ng-template pTemplate="body" let-h>
-    <tr>
-      <td>{{ h.codigo }}</td>
-      <td>{{ h.apto }}</td>
-      <td>{{ h.nome_completo }}</td>
-      <td>{{ h.endereco }}</td>
-      <td>{{ h.estado }}</td>
-      <td>{{ h.email }}</td>
-      <td>{{ h.profissao }}</td>
-      <td>{{ h.cidade }}</td>
-      <td>{{ h.identidade }}</td>
-      <td>{{ h.cpf }}</td>
-      <td>{{ h.telefone }}</td>
-      <td>{{ h.pais }}</td>
-      <td>{{ h.cep }}</td>
-      <td>{{ h.data_nascimento }}</td>
-      <td>{{ h.sexo }}</td>
-      <td>{{ h.entrada }}</td>
-      <td>{{ h.saida }}</td>
-      <td>{{ h.idhospede || '-' }}</td>
-      <td>{{ h.idreservasfront || '-' }}</td>
-      <td>
-        <p-button
-          icon="pi pi-search"
-          label="Compatibilidade"
-          (click)="buscarCompatibilidade(h)"
-          [loading]="buscandoCompatibilidade[h.id]"
-          styleClass="compatibilidade-button"
-        ></p-button>
-        <p-button icon="pi pi-trash" severity="danger" (click)="remove(h.id)" rounded outlined></p-button>
-      </td>
-    </tr>
-  </ng-template>
-</p-table>
+
+  <ng-container *ngIf="paginatedHospedes.length; else emptyState">
+    <div class="cards-grid">
+      <p-card *ngFor="let h of paginatedHospedes" styleClass="hospede-card">
+        <ng-template pTemplate="title">
+          <div class="card-title">
+            <span class="card-title__name">{{ h.nome_completo || 'Hóspede sem nome' }}</span>
+            <p-tag
+              *ngIf="h.apto; else semApto"
+              severity="info"
+              value="Apto {{ h.apto }}"
+            ></p-tag>
+            <ng-template #semApto>
+              <p-tag severity="warning" value="Apto não informado"></p-tag>
+            </ng-template>
+          </div>
+        </ng-template>
+
+        <ng-template pTemplate="subtitle">
+          <div class="card-subtitle">Código #{{ h.codigo || '-' }}</div>
+        </ng-template>
+
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="label">E-mail</span>
+            <span class="value">{{ h.email || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Telefone</span>
+            <span class="value">{{ h.telefone || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Profissão</span>
+            <span class="value">{{ h.profissao || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Documento</span>
+            <span class="value">{{ h.identidade || h.cpf || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Nascimento</span>
+            <span class="value">{{ h.data_nascimento || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Sexo</span>
+            <span class="value">{{ h.sexo || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Endereço</span>
+            <span class="value">{{ h.endereco || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Cidade/UF</span>
+            <span class="value">{{ h.cidade || '-' }} - {{ h.estado || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">País</span>
+            <span class="value">{{ h.pais || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">CEP</span>
+            <span class="value">{{ h.cep || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Entrada</span>
+            <span class="value">{{ h.entrada || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">Saída</span>
+            <span class="value">{{ h.saida || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">ID Hóspede Oracle</span>
+            <span class="value">{{ h.idhospede || '-' }}</span>
+          </div>
+          <div class="info-item">
+            <span class="label">ID Reserva Oracle</span>
+            <span class="value">{{ h.idreservasfront || '-' }}</span>
+          </div>
+        </div>
+
+        <div class="card-footer">
+          <p-button
+            icon="pi pi-search"
+            label="Compatibilidade"
+            (click)="buscarCompatibilidade(h)"
+            [loading]="buscandoCompatibilidade[h.id]"
+            styleClass="compatibilidade-button"
+          ></p-button>
+          <p-button icon="pi pi-trash" severity="danger" (click)="remove(h.id)" rounded outlined></p-button>
+        </div>
+      </p-card>
+    </div>
+  </ng-container>
+</p-panel>
+
+<ng-template #emptyState>
+  <div class="empty-state">
+    <i class="pi pi-users"></i>
+    <h3>Nenhum hóspede encontrado</h3>
+    <p>Importe uma planilha para começar a visualizar os registros.</p>
+  </div>
+</ng-template>
+
+<p-paginator
+  [first]="page * rows"
+  [rows]="rows"
+  [rowsPerPageOptions]="[6, 9, 12, 24]"
+  [totalRecords]="hospedes.length"
+  (onPageChange)="onPageChange($event)"
+></p-paginator>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.scss
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.scss
@@ -1,15 +1,174 @@
 :host {
   display: block;
-  padding: 1rem;
+  padding: 1.5rem;
+  background: var(--surface-ground, #f5f5f5);
 }
 
-.header {
+.hospedes-panel {
+  border: none;
+  box-shadow: var(--p-panel-shadow, 0 10px 30px rgba(15, 23, 42, 0.08));
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.panel-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--p-surface-900, #1f2937);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--p-surface-500, #64748b);
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 100%);
+}
+
+.hospede-card {
+  border-radius: 1rem !important;
+  overflow: hidden;
+  box-shadow: var(--p-card-shadow, 0 20px 40px rgba(15, 23, 42, 0.08));
+  border: none;
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.card-title__name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--p-surface-900, #1f2937);
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--p-surface-500, #64748b);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin: 1.25rem 0 1.5rem;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--p-primary-50, #eff6ff) 50%, transparent);
+  border: 1px solid color-mix(in srgb, var(--p-primary-200, #bfdbfe) 35%, transparent);
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--p-surface-500, #64748b);
+}
+
+.value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--p-surface-800, #1f2937);
+  word-break: break-word;
+}
+
+.card-footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
+  margin-top: auto;
 }
 
 .compatibilidade-button {
-  margin-right: 0.5rem;
+  flex: 1;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 1.5rem;
+  background: white;
+  border-radius: 1rem;
+  color: var(--p-surface-500, #64748b);
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  margin: 2rem auto;
+  max-width: 460px;
+}
+
+.empty-state i {
+  font-size: 2.5rem;
+  color: var(--p-primary-color, var(--p-primary-500, #2563eb));
+}
+
+.empty-state h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--p-surface-700, #334155);
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+p-paginator {
+  margin-top: 1.5rem;
+  display: block;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 1rem;
+  }
+
+  .cards-grid {
+    padding: 1rem;
+  }
+
+  .card-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .compatibilidade-button {
+    width: 100%;
+  }
 }

--- a/frontend/src/app/components/hospedes-list/hospedes-list.ts
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.ts
@@ -1,25 +1,38 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
+import { PanelModule } from 'primeng/panel';
+import { CardModule } from 'primeng/card';
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
+import { TagModule } from 'primeng/tag';
 import { HospedesService } from '../../services/hospedes.service';
 
 @Component({
   selector: 'app-hospedes-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, TableModule, ButtonModule],
+  imports: [CommonModule, RouterModule, ButtonModule, PanelModule, CardModule, PaginatorModule, TagModule],
   templateUrl: './hospedes-list.html',
   styleUrls: ['./hospedes-list.scss']
 })
 export class HospedesListComponent implements OnInit {
   hospedes: any[] = [];
   buscandoCompatibilidade: Record<number, boolean> = {};
+  page = 0;
+  rows = 9;
 
   constructor(private service: HospedesService) {}
 
   ngOnInit(): void {
-    this.service.list().subscribe(data => this.hospedes = data);
+    this.service.list().subscribe(data => {
+      this.hospedes = data ?? [];
+      this.page = 0;
+    });
+  }
+
+  get paginatedHospedes(): any[] {
+    const start = this.page * this.rows;
+    return this.hospedes.slice(start, start + this.rows);
   }
 
   buscarCompatibilidade(hospede: any): void {
@@ -54,6 +67,26 @@ export class HospedesListComponent implements OnInit {
   remove(id: number): void {
     this.service.delete(id).subscribe(() => {
       this.hospedes = this.hospedes.filter(h => h.id !== id);
+      this.adjustPage();
     });
+  }
+
+  onPageChange(event: PaginatorState): void {
+    if (typeof event.page === 'number') {
+      this.page = event.page;
+    }
+
+    if (typeof event.rows === 'number') {
+      this.rows = event.rows;
+      this.adjustPage();
+    }
+  }
+
+  private adjustPage(): void {
+    const totalPages = Math.ceil(this.hospedes.length / this.rows) || 1;
+    const lastPage = Math.max(totalPages - 1, 0);
+    if (this.page > lastPage) {
+      this.page = lastPage;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the table-based hóspedes listing with a modern PrimeNG panel and card grid
- add client-side pagination using PrimeNG paginator and improve action buttons and empty state messaging
- refresh the component styling with responsive card layouts and updated visual hierarchy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb10f80bb4832ebc885dd4a7fef9bb