### PR TITLE
feat: add filtering and detail dialog to hospedes list

### DIFF
--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -5,117 +5,179 @@
         <h2>Hóspedes</h2>
         <p class="subtitle">Visualize e gerencie os cadastros importados do hotel.</p>
       </div>
-      <p-button label="Importar planilha" icon="pi pi-upload" [routerLink]="['/hospedes/import']"></p-button>
+      <div class="panel-header__actions">
+        <span class="p-input-icon-left filter-input">
+          <i class="pi pi-search"></i>
+          <input
+            type="text"
+            pInputText
+            placeholder="Filtrar hóspedes"
+            [(ngModel)]="filterTerm"
+            (ngModelChange)="onFilterChange()"
+          />
+        </span>
+        <p-button label="Importar planilha" icon="pi pi-upload" [routerLink]="['/hospedes/import']"></p-button>
+      </div>
     </div>
   </ng-template>
 
   <ng-container *ngIf="paginatedHospedes.length; else emptyState">
-    <div class="cards-grid">
-      <p-card *ngFor="let h of paginatedHospedes" styleClass="hospede-card">
-        <ng-template pTemplate="title">
-          <div class="card-title">
-            <span class="card-title__name">{{ h.nome_completo || 'Hóspede sem nome' }}</span>
-            <p-tag
-              *ngIf="h.apto; else semApto"
-              severity="info"
-              value="Apto {{ h.apto }}"
-            ></p-tag>
-            <ng-template #semApto>
-              <p-tag severity="warning" value="Apto não informado"></p-tag>
-            </ng-template>
-          </div>
-        </ng-template>
-
-        <ng-template pTemplate="subtitle">
-          <div class="card-subtitle">Código #{{ h.codigo || '-' }}</div>
-        </ng-template>
-
-        <div class="info-grid">
-          <div class="info-item">
-            <span class="label">E-mail</span>
-            <span class="value">{{ h.email || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Telefone</span>
-            <span class="value">{{ h.telefone || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Profissão</span>
-            <span class="value">{{ h.profissao || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Documento</span>
-            <span class="value">{{ h.identidade || h.cpf || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Nascimento</span>
-            <span class="value">{{ h.data_nascimento || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Sexo</span>
-            <span class="value">{{ h.sexo || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Endereço</span>
-            <span class="value">{{ h.endereco || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Cidade/UF</span>
-            <span class="value">{{ h.cidade || '-' }} - {{ h.estado || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">País</span>
-            <span class="value">{{ h.pais || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">CEP</span>
-            <span class="value">{{ h.cep || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Entrada</span>
-            <span class="value">{{ h.entrada || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">Saída</span>
-            <span class="value">{{ h.saida || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">ID Hóspede Oracle</span>
-            <span class="value">{{ h.idhospede || '-' }}</span>
-          </div>
-          <div class="info-item">
-            <span class="label">ID Reserva Oracle</span>
-            <span class="value">{{ h.idreservasfront || '-' }}</span>
-          </div>
-        </div>
-
-        <div class="card-footer">
-          <p-button
-            icon="pi pi-search"
-            label="Compatibilidade"
-            (click)="buscarCompatibilidade(h)"
-            [loading]="buscandoCompatibilidade[h.id]"
-            styleClass="compatibilidade-button"
-          ></p-button>
-          <p-button icon="pi pi-trash" severity="danger" (click)="remove(h.id)" rounded outlined></p-button>
-        </div>
-      </p-card>
+    <div class="table-container">
+      <table class="hospedes-table">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>E-mail</th>
+            <th>Telefone</th>
+            <th>Chegada</th>
+            <th>Partida</th>
+            <th>Status</th>
+            <th class="actions-column">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let h of paginatedHospedes">
+            <td>
+              <div class="name-cell">
+                <span class="name">{{ h.nome_completo || 'Hóspede sem nome' }}</span>
+                <small class="codigo" *ngIf="h.codigo">Código #{{ h.codigo }}</small>
+              </div>
+            </td>
+            <td>{{ h.email || '-' }}</td>
+            <td>{{ h.telefone || '-' }}</td>
+            <td>{{ h.entrada || '-' }}</td>
+            <td>{{ h.saida || '-' }}</td>
+            <td>{{ h.status || '-' }}</td>
+            <td>
+              <div class="actions">
+                <p-button icon="pi pi-search" rounded (click)="showDetalhes(h)" [text]="true"></p-button>
+                <p-button
+                  label="Compatibilidade"
+                  icon="pi pi-check"
+                  (click)="buscarCompatibilidade(h)"
+                  [loading]="buscandoCompatibilidade[h.id]"
+                  styleClass="compatibilidade-button"
+                ></p-button>
+                <p-button icon="pi pi-trash" severity="danger" (click)="remove(h.id)" rounded outlined></p-button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </ng-container>
 </p-panel>
 
 <ng-template #emptyState>
+  <ng-container *ngIf="!filterTerm; else filteredEmpty">
+    <div class="empty-state">
+      <i class="pi pi-users"></i>
+      <h3>Nenhum hóspede encontrado</h3>
+      <p>Importe uma planilha para começar a visualizar os registros.</p>
+    </div>
+  </ng-container>
+</ng-template>
+
+<ng-template #filteredEmpty>
   <div class="empty-state">
-    <i class="pi pi-users"></i>
-    <h3>Nenhum hóspede encontrado</h3>
-    <p>Importe uma planilha para começar a visualizar os registros.</p>
+    <i class="pi pi-search"></i>
+    <h3>Nenhum resultado para o filtro</h3>
+    <p>Altere os termos de busca para visualizar outros registros.</p>
   </div>
 </ng-template>
 
 <p-paginator
+  *ngIf="totalRecords"
   [first]="page * rows"
   [rows]="rows"
-  [rowsPerPageOptions]="[6, 9, 12, 24]"
-  [totalRecords]="hospedes.length"
+  [rowsPerPageOptions]="[10, 20, 50]"
+  [totalRecords]="totalRecords"
   (onPageChange)="onPageChange($event)"
 ></p-paginator>
+
+<p-dialog
+  [(visible)]="detailDialogVisible"
+  [modal]="true"
+  [style]="{ width: '640px' }"
+  [breakpoints]="{ '960px': '90vw' }"
+  [draggable]="false"
+  appendTo="body"
+  styleClass="detalhes-dialog"
+  (onHide)="onDialogHide()"
+  [header]="selectedHospede?.nome_completo || 'Detalhes do hóspede'"
+>
+  <div class="dialog-header-info" *ngIf="selectedHospede">
+    <p-tag
+      *ngIf="selectedHospede.apto; else semApartamento"
+      severity="info"
+      [value]="'Apto ' + selectedHospede.apto"
+    ></p-tag>
+    <ng-template #semApartamento>
+      <p-tag severity="warning" value="Apto não informado"></p-tag>
+    </ng-template>
+    <span class="dialog-codigo" *ngIf="selectedHospede.codigo">Código #{{ selectedHospede.codigo }}</span>
+  </div>
+
+  <div class="info-grid" *ngIf="selectedHospede">
+    <div class="info-item">
+      <span class="label">E-mail</span>
+      <span class="value">{{ selectedHospede.email || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Telefone</span>
+      <span class="value">{{ selectedHospede.telefone || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Profissão</span>
+      <span class="value">{{ selectedHospede.profissao || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Documento</span>
+      <span class="value">{{ selectedHospede.identidade || selectedHospede.cpf || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Nascimento</span>
+      <span class="value">{{ selectedHospede.data_nascimento || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Sexo</span>
+      <span class="value">{{ selectedHospede.sexo || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Endereço</span>
+      <span class="value">{{ selectedHospede.endereco || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Cidade/UF</span>
+      <span class="value">{{ selectedHospede.cidade || '-' }} - {{ selectedHospede.estado || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">País</span>
+      <span class="value">{{ selectedHospede.pais || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">CEP</span>
+      <span class="value">{{ selectedHospede.cep || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Entrada</span>
+      <span class="value">{{ selectedHospede.entrada || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Saída</span>
+      <span class="value">{{ selectedHospede.saida || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">Status</span>
+      <span class="value">{{ selectedHospede.status || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">ID Hóspede Oracle</span>
+      <span class="value">{{ selectedHospede.idhospede || '-' }}</span>
+    </div>
+    <div class="info-item">
+      <span class="label">ID Reserva Oracle</span>
+      <span class="value">{{ selectedHospede.idreservasfront || '-' }}</span>
+    </div>
+  </div>
+</p-dialog>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.scss
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.scss
@@ -31,42 +31,109 @@
   color: var(--p-surface-900, #1f2937);
 }
 
+.panel-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-input {
+  display: inline-flex;
+  align-items: center;
+  background: white;
+  border-radius: 999px;
+  padding: 0 0.75rem;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--p-surface-200, #e2e8f0) 65%, transparent);
+}
+
+.filter-input input {
+  border: none;
+  box-shadow: none;
+  padding: 0.5rem 0.25rem;
+  width: 220px;
+}
+
+.filter-input input:focus {
+  box-shadow: none;
+}
+
 .subtitle {
   margin: 0;
   font-size: 0.95rem;
   color: var(--p-surface-500, #64748b);
 }
 
-.cards-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.5rem;
+.table-container {
   padding: 1.5rem;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 100%);
 }
 
-.hospede-card {
-  border-radius: 1rem !important;
+.hospedes-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: white;
+  border-radius: 1rem;
   overflow: hidden;
-  box-shadow: var(--p-card-shadow, 0 20px 40px rgba(15, 23, 42, 0.08));
-  border: none;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
 }
 
-.card-title {
+.hospedes-table thead {
+  background: color-mix(in srgb, var(--p-primary-500, #2563eb) 8%, white);
+}
+
+.hospedes-table th {
+  text-align: left;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--p-surface-500, #64748b);
+  padding: 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--p-surface-200, #e2e8f0) 70%, transparent);
+}
+
+.hospedes-table td {
+  padding: 1rem;
+  font-size: 0.95rem;
+  color: var(--p-surface-800, #1f2937);
+  border-bottom: 1px solid color-mix(in srgb, var(--p-surface-200, #e2e8f0) 65%, transparent);
+  vertical-align: middle;
+}
+
+.hospedes-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.name {
+  font-weight: 600;
+  color: var(--p-surface-900, #1f2937);
+}
+
+.codigo {
+  color: var(--p-surface-400, #94a3b8);
+}
+
+.actions-column {
+  width: 280px;
+}
+
+.actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.card-title__name {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--p-surface-900, #1f2937);
+.actions :deep(.p-button) {
+  min-width: auto;
 }
 
-.card-subtitle {
-  font-size: 0.85rem;
-  color: var(--p-surface-500, #64748b);
+.compatibilidade-button {
+  flex-shrink: 0;
 }
 
 .info-grid {
@@ -99,18 +166,6 @@
   font-weight: 500;
   color: var(--p-surface-800, #1f2937);
   word-break: break-word;
-}
-
-.card-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: auto;
-}
-
-.compatibilidade-button {
-  flex: 1;
 }
 
 .empty-state {
@@ -154,21 +209,52 @@ p-paginator {
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
+.detalhes-dialog :deep(.p-dialog-content) {
+  padding-top: 0;
+}
+
+.dialog-header-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.dialog-codigo {
+  font-size: 0.9rem;
+  color: var(--p-surface-500, #64748b);
+}
+
 @media (max-width: 768px) {
   :host {
     padding: 1rem;
   }
 
-  .cards-grid {
-    padding: 1rem;
-  }
-
-  .card-footer {
+  .panel-header__actions {
+    width: 100%;
     flex-direction: column;
     align-items: stretch;
   }
 
-  .compatibilidade-button {
+  .filter-input {
     width: 100%;
+    padding-right: 1rem;
+  }
+
+  .filter-input input {
+    width: 100%;
+  }
+
+  .table-container {
+    padding: 1rem;
+    overflow-x: auto;
+  }
+
+  .actions-column {
+    width: 240px;
+  }
+
+  .actions {
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## Summary
- add search filter and paginator integration for the hóspedes list
- replace card grid with a table showing key guest info and action buttons
- introduce a detail dialog that exposes the remaining guest fields with refreshed styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb14d9a358832ea56f4cc70daece65