### PR TITLE
Ajusta status textual de hóspedes e adiciona endpoint de integração

### DIFF
--- a/backend/routes/hospedes.js
+++ b/backend/routes/hospedes.js
@@ -124,7 +124,28 @@ router.post('/import', upload.single('file'), async (req, res, next) => {
       inserts.push(db.query(
         `INSERT INTO hospedes (codigo, apto, nome_completo, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, data_nascimento, sexo, entrada, saida, status, idhospede, idreservasfront)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [codigo, apto, nomeCompleto, endereco, estado, email, profissao, cidade, identidade, cpf, telefone, pais, cep, dataNascimento, sexo, entrada, saida, 1, null, null]
+        [
+          codigo,
+          apto,
+          nomeCompleto,
+          endereco,
+          estado,
+          email,
+          profissao,
+          cidade,
+          identidade,
+          cpf,
+          telefone,
+          pais,
+          cep,
+          dataNascimento,
+          sexo,
+          entrada,
+          saida,
+          'importado',
+          null,
+          null
+        ]
       ));
     }
     await Promise.all(inserts);
@@ -182,9 +203,12 @@ router.post('/:id/compatibilidade', async (req, res, next) => {
     });
 
     if (!reservas || reservas.length === 0) {
+      await db.query('UPDATE hospedes SET status = ? WHERE id = ?', ['Não Compativel', req.params.id]);
+      const atualizado = await db.query('SELECT * FROM hospedes WHERE id = ?', [req.params.id]);
+
       return res.json({
         message: 'Nenhuma reserva compatível encontrada no Oracle',
-        hospede,
+        hospede: atualizado.rows[0],
         reserva: null,
         compatibilidadeEncontrada: false
       });
@@ -196,9 +220,10 @@ router.post('/:id/compatibilidade', async (req, res, next) => {
     const idReservasFrontOracle =
       reserva.IDRESERVASFRONT ?? reserva.idreservasfront ?? reserva.IdReservasFront ?? reserva.idReservasFront ?? null;
 
-    await db.query('UPDATE hospedes SET idhospede = ?, idreservasfront = ? WHERE id = ?', [
+    await db.query('UPDATE hospedes SET idhospede = ?, idreservasfront = ?, status = ? WHERE id = ?', [
       idHospedeOracle,
       idReservasFrontOracle,
+      'compativel',
       req.params.id
     ]);
 
@@ -214,6 +239,46 @@ router.post('/:id/compatibilidade', async (req, res, next) => {
     if (err && err.message && err.message.includes('Oracle Database indisponível')) {
       return res.status(503).json({ error: err.message });
     }
+    next(err);
+  }
+});
+
+// Marcar hóspede como integrado ao PMS
+router.post('/:id/integrar', async (req, res, next) => {
+  try {
+    const db = getSqliteDb();
+    await garantirColunasExtras(db);
+
+    const hospedeResult = await db.query('SELECT * FROM hospedes WHERE id = ?', [req.params.id]);
+
+    if (hospedeResult.rowCount === 0) {
+      return res.status(404).json({ error: 'Hóspede não encontrado' });
+    }
+
+    const atualizacoes = ['status = ?'];
+    const parametros = ['integrado'];
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'idhospede')) {
+      atualizacoes.push('idhospede = ?');
+      parametros.push(req.body.idhospede);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'idreservasfront')) {
+      atualizacoes.push('idreservasfront = ?');
+      parametros.push(req.body.idreservasfront);
+    }
+
+    parametros.push(req.params.id);
+
+    await db.query(`UPDATE hospedes SET ${atualizacoes.join(', ')} WHERE id = ?`, parametros);
+
+    const atualizado = await db.query('SELECT * FROM hospedes WHERE id = ?', [req.params.id]);
+
+    res.json({
+      message: 'Hóspede marcado como integrado ao PMS',
+      hospede: atualizado.rows[0]
+    });
+  } catch (err) {
     next(err);
   }
 });

--- a/frontend/src/app/components/hospedes-list/hospedes-list.html
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.html
@@ -47,7 +47,7 @@
             <td>{{ h.telefone || '-' }}</td>
             <td>{{ h.entrada || '-' }}</td>
             <td>{{ h.saida || '-' }}</td>
-            <td>{{ h.status || '-' }}</td>
+            <td>{{ getStatusLabel(h.status) }}</td>
             <td>
               <div class="actions">
                 <p-button icon="pi pi-search" rounded (click)="showDetalhes(h)" [text]="true"></p-button>
@@ -169,7 +169,7 @@
     </div>
     <div class="info-item">
       <span class="label">Status</span>
-      <span class="value">{{ selectedHospede.status || '-' }}</span>
+      <span class="value">{{ getStatusLabel(selectedHospede.status) }}</span>
     </div>
     <div class="info-item">
       <span class="label">ID Hóspede Oracle</span>

--- a/frontend/src/app/components/hospedes-list/hospedes-list.ts
+++ b/frontend/src/app/components/hospedes-list/hospedes-list.ts
@@ -36,6 +36,14 @@ export class HospedesListComponent implements OnInit {
   detailDialogVisible = false;
   selectedHospede: any | null = null;
 
+  private readonly statusLabels: Record<string, string> = {
+    importado: 'Importado',
+    compativel: 'Compatível',
+    'não compativel': 'Não Compatível',
+    'nao compativel': 'Não Compatível',
+    integrado: 'Integrado'
+  };
+
   constructor(private service: HospedesService) {}
 
   ngOnInit(): void {
@@ -136,6 +144,28 @@ export class HospedesListComponent implements OnInit {
   onDialogHide(): void {
     this.detailDialogVisible = false;
     this.selectedHospede = null;
+  }
+
+  getStatusLabel(status: unknown): string {
+    if (status === null || status === undefined || status === '') {
+      return '-';
+    }
+
+    const texto = String(status).trim();
+    if (!texto) {
+      return '-';
+    }
+
+    const normalizado = texto.toLowerCase();
+    const label = this.statusLabels[normalizado];
+    if (label) {
+      return label;
+    }
+
+    return texto
+      .split(/\s+/)
+      .map(parte => parte.charAt(0).toUpperCase() + parte.slice(1))
+      .join(' ');
   }
 
   private includesTerm(value: unknown, term: string): boolean {

--- a/frontend/src/app/services/hospedes.service.ts
+++ b/frontend/src/app/services/hospedes.service.ts
@@ -23,6 +23,10 @@ export class HospedesService {
     return this.http.post<any>(`${this.baseUrl}/${id}/compatibilidade`, {});
   }
 
+  marcarIntegrado(id: number, payload: { idhospede?: string; idreservasfront?: string } = {}): Observable<any> {
+    return this.http.post<any>(`${this.baseUrl}/${id}/integrar`, payload);
+  }
+
   delete(id: number): Observable<void> {
     return this.http.delete<void>(`${this.baseUrl}/${id}`);
   }


### PR DESCRIPTION
## Summary
- salva novos hóspedes importados com status textual "importado" e ajusta atualizações de compatibilidade para registrar estados compatível ou não compatível
- adiciona endpoint para marcar hóspedes como integrados ao PMS preservando atualizações opcionais de identificadores externos
- normaliza a apresentação do status na listagem e no diálogo de detalhes para exibir rótulos legíveis no frontend

## Testing
- npm run lint (frontend) *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68cc1a5f49a0832ebaa1b1473c5bb0b6